### PR TITLE
fix cptr.c builds on macos

### DIFF
--- a/support/cptr.c
+++ b/support/cptr.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 void *cptr_malloc(size_t bytes) {
   if (bytes == 0) {


### PR DESCRIPTION
I was getting the following error until I added an include of `time.h`.
```
cptr.c:68:25: error: invalid application of 'sizeof' to an incomplete type 'struct timespec'
758
  return cptr_calloc(1, sizeof(struct timespec));
759
                        ^     ~~~~~~~~~~~~~~~~~
```
Adding the include seems reasonable and has no negative impact on Linux builds.