### PR TITLE
[ refactor, performance ] much faster C pointers

### DIFF
--- a/codegen/integer.c
+++ b/codegen/integer.c
@@ -18,7 +18,7 @@ void *stype(char *name, size_t sz) {
 
 void *tsize(char *name, size_t sz) {
   printf("\npublic export %%inline\n");
-  printf("%sSize : Nat\n", name);
+  printf("%sSize : Bits32\n", name);
   printf("%sSize = %zd\n", name, sz);
 }
 

--- a/cptr.ipkg
+++ b/cptr.ipkg
@@ -8,6 +8,7 @@ depends = base >= 0.6.0
         , array
 
 modules = Data.C.Array
+        , Data.C.Array8
         , Data.C.Deref
         , Data.C.Integer
         , Data.C.Ptr

--- a/pack.toml
+++ b/pack.toml
@@ -19,3 +19,9 @@ type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-ref1"
 commit = "latest:main"
 ipkg   = "ref1.ipkg"
+
+[custom.all.profiler]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-profiler"
+commit = "latest:main"
+ipkg   = "profiler.ipkg"

--- a/profile/src/Main.idr
+++ b/profile/src/Main.idr
@@ -3,6 +3,7 @@ module Main
 import Data.Buffer.Indexed
 import Data.Array
 import Data.C.Ptr
+import Data.C.Array8 as A8
 import Profile
 
 %default total
@@ -15,6 +16,9 @@ sumEmptyBuffer n = foldr (\x,y => cast x + y) 0 (Buffer.Indexed.fill n 1)
 
 sumEmptyCptr : Nat -> Bits32
 sumEmptyCptr n = withCArray {a = Bits32} n $ \r => withIArray r (foldr (+) 0)
+
+sumEmptyArray8 : Nat -> Bits32
+sumEmptyArray8 n = A8.withCArray n $ \r => A8.withIArray r (foldr (\x,y => cast x + y) 0)
 
 bench : Benchmark Void
 bench = Group "ref1"
@@ -32,6 +36,11 @@ bench = Group "ref1"
       [ Single "1"       (basic sumEmptyCptr 1)
       , Single "1000"    (basic sumEmptyCptr 1000)
       , Single "1000000" (basic sumEmptyCptr 1000000)
+      ]
+  , Group "sum CArray8"
+      [ Single "1"       (basic sumEmptyArray8 1)
+      , Single "1000"    (basic sumEmptyArray8 1000)
+      , Single "1000000" (basic sumEmptyArray8 1000000)
       ]
   ]
 

--- a/src/Data/C/Array8.idr
+++ b/src/Data/C/Array8.idr
@@ -1,0 +1,263 @@
+module Data.C.Array8
+
+import Data.C.Integer
+import Data.C.Array
+import Data.Vect
+
+import public Data.Fin
+import public Data.Linear.Token
+import public Data.Array.Index
+
+import Syntax.T1
+
+%default total
+
+export %foreign "scheme,chez:(lambda (x y z) (foreign-set! 'unsigned-8 x y z))"
+prim__setbits8 : AnyPtr -> Integer -> Bits8 -> PrimIO ()
+
+export %foreign "scheme,chez:(lambda (x y) (foreign-ref 'unsigned-8 x y))"
+prim__getbits8 : AnyPtr -> Integer -> Bits8
+
+--------------------------------------------------------------------------------
+-- Immutable API
+--------------------------------------------------------------------------------
+
+export
+record CIArray8 (n : Nat) where
+  constructor IA
+  ptr : AnyPtr
+
+export %inline
+at : CIArray8 n -> Fin n -> Bits8
+at r x = prim__getbits8 r.ptr (cast $ finToNat x)
+
+export %inline
+ix : CIArray8 n -> (0 m : Nat) -> (x : Ix (S m) n) => Bits8
+ix r m = at r (ixToFin x)
+
+export %inline
+atNat : CIArray8 n -> (m : Nat) -> (0 lt : LT m n) => Bits8
+atNat r m = at r (natToFinLT m)
+
+foldrI : (m : Nat) -> (0 _ : LTE m n) => (Bits8 -> b -> b) -> b -> CIArray8 n -> b
+foldrI 0     _ x r = x
+foldrI (S k) f x r = foldrI k f (f (atNat r k) x) r
+
+foldrKV_ :
+     (m : Nat)
+  -> {auto 0 prf : LTE m n}
+  -> (Fin n -> Bits8 -> b -> b)
+  -> b
+  -> CIArray8 n
+  -> b
+foldrKV_ 0     _ x r = x
+foldrKV_ (S k) f x r =
+  let fin := natToFinLT k @{prf} in foldrKV_ k f (f fin (at r fin) x) r
+
+foldlI : (m : Nat) -> (x : Ix m n) => (b -> Bits8 -> b) -> b -> CIArray8 n -> b
+foldlI 0     _ v r = v
+foldlI (S k) f v r = foldlI k f (f v (ix r k)) r
+
+foldlKV_ :
+     (m : Nat)
+  -> {auto x : Ix m n}
+  -> (Fin n -> b -> Bits8 -> b)
+  -> b
+  -> CIArray8 n
+  -> b
+foldlKV_ 0     _ v r = v
+foldlKV_ (S k) f v r =
+  let fin := ixToFin x in foldlKV_ k f (f fin v (at r fin)) r
+
+ontoVect :
+     (r : CIArray8 n)
+  -> Vect m Bits8
+  -> (k : Nat)
+  -> {auto 0 lt : LTE k n}
+  -> Vect (m+k) Bits8
+ontoVect r vs 0     = rewrite plusCommutative m 0 in vs
+ontoVect r vs (S x) =
+  let v := atNat r x {lt}
+   in rewrite sym (plusSuccRightSucc m x) in ontoVect r (v::vs) x
+
+||| Reads the values from a C pointer into a vector.
+export %inline
+toVect : {n : _} -> (r : CIArray8 n) -> Vect n Bits8
+toVect r = ontoVect r [] n
+
+||| Right fold over the values of an array plus their indices.
+export %inline
+foldrKV : {n : _} -> (Fin n -> Bits8 -> b -> b) -> b -> CIArray8 n -> b
+foldrKV = foldrKV_ n
+
+||| Right fold over the values of an array
+export %inline
+foldr : {n : _} -> (Bits8 -> b -> b) -> b -> CIArray8 n -> b
+foldr = foldrI n
+
+||| Left fold over the values of an array plus their indices.
+export %inline
+foldlKV : {n : _} -> (Fin n -> b -> Bits8 -> b) -> b -> CIArray8 n -> b
+foldlKV = foldlKV_ n
+
+||| Left fold over the values of an array
+export %inline
+foldl : {n : _} -> (b -> Bits8 -> b) -> b -> CIArray8 n -> b
+foldl = foldlI n
+
+--------------------------------------------------------------------------------
+-- IO-API
+--------------------------------------------------------------------------------
+
+export
+record CArray8' (t : RTag) (n : Nat) where
+  constructor CA
+  ptr : AnyPtr
+
+||| Convenience alias for `CArray8' RPure`
+public export
+0 CArray8 : Nat -> Type
+CArray8 = CArray8' RPure
+
+||| Convenience alias for `CArray8' RIO`
+public export
+0 CArray8IO : Nat -> Type
+CArray8IO = CArray8' RIO
+
+public export
+InIO (CArray8' RIO n) where
+
+export %inline
+unsafeUnwrap : CArray8' t n -> AnyPtr
+unsafeUnwrap = ptr
+
+export %inline
+unsafeWrap : AnyPtr -> CArray8' t n
+unsafeWrap = CA
+
+parameters {auto has : HasIO io}
+
+  ||| Allocates a new C-pointer of `sizeof a * n` bytes.
+  export %inline
+  malloc : (n : Nat) -> io (CArray8IO n)
+  malloc n = primIO $ MkIORes (CA $ prim__malloc (cast n))
+
+  ||| Like `malloc` but resets all allocated bytes to zero.
+  export %inline
+  calloc : (n : Nat) -> io (CArray8IO n)
+  calloc n =
+    primIO $ MkIORes (CA $ prim__calloc (cast n) 1)
+
+  export %inline
+  free : CArray8IO n -> io ()
+  free (CA p) = primIO $ prim__free p
+
+--------------------------------------------------------------------------------
+-- Linear API
+--------------------------------------------------------------------------------
+
+||| Allocates a new C-pointer of `sizeof a * n` bytes.
+export %inline
+malloc1 : (n : Nat) -> (1 t : T1 rs) -> A1 rs (CArray8 n)
+malloc1 n t =
+  let p := prim__malloc (cast n)
+   in A (CA p) (unsafeBind t)
+
+||| Like `malloc1` but resets all allocated bytes to zero.
+export %inline
+calloc1 : (n : Nat) -> (1 t : T1 rs) -> A1 rs (CArray8 n)
+calloc1 n t =
+  let p := prim__calloc (cast n) 1
+   in A (CA p) (unsafeBind t)
+
+||| Frees the memory allocated for a C pointer and removes it from the
+||| resources bound to the linear token.
+export %inline
+free1 : (r : CArray8 n) -> (0 p : Res r rs) => C1' rs (Drop rs p)
+free1 r t =
+  let MkIORes _ _ := prim__free r.ptr %MkWorld
+   in unsafeRelease p t
+
+parameters {0 n      : Nat}
+           {0 rs     : Resources}
+           (r        : CArray8' t n)
+           {auto 0 p : Res r rs}
+
+  ||| Reads a value from a C-pointer at the given position.
+  export %inline
+  get : Fin n -> F1 rs Bits8
+  get x t = prim__getbits8 r.ptr (cast $ finToNat x) # t
+
+  ||| Reads a value from a C-pointer at the given position.
+  export %inline
+  getIx : (0 m : Nat) -> (x : Ix (S m) n) => F1 rs Bits8
+  getIx m = get (ixToFin x)
+
+  ||| Reads a value from a C-pointer at the given position.
+  export %inline
+  getNat : (m : Nat) -> (0 lt : LT m n) => F1 rs Bits8
+  getNat m = get (natToFinLT m)
+
+  ||| Writes a value to a C pointer at the given position.
+  export %inline
+  set : Fin n -> Bits8 -> F1' rs
+  set x v = ffi $ prim__setbits8 r.ptr (cast $ finToNat x) v
+
+  ||| Writes a value to a C pointer at the given position.
+  export %inline
+  setIx : (0 m : Nat) -> (x : Ix (S m) n) => Bits8 -> F1' rs
+  setIx m = set (ixToFin x)
+
+  ||| Writes a value to a C pointer at the given position.
+  export %inline
+  setNat : (m : Nat) -> (0 lt : LT m n) => Bits8 -> F1' rs
+  setNat m = set (natToFinLT m)
+
+  writeVect1 : Vect k Bits8 -> Ix k n => F1' rs
+  writeVect1           []        t = () # t
+  writeVect1 {k = S m} (x :: xs) t =
+    let _ # t := Array8.setIx m x t
+     in writeVect1 xs t
+
+  ||| Writes the values from a vector to a C pointer
+  export %inline
+  writeVect : Vect n Bits8 -> F1' rs
+  writeVect as = writeVect1 as
+
+  ||| Temporarily wraps the mutable array in an immutable wrapper and
+  ||| run a computation with that.
+  |||
+  ||| This is safe, because the pure function cannot possibly share the
+  ||| immutable array by storing it in a mutable reference. It is
+  ||| referentially transparent, because we call it from a linear context.
+  export %inline
+  withIArray : (CIArray8 n -> b) -> F1 rs b
+  withIArray f t = f (IA r.ptr) # t
+
+||| Writes the values from a list to a C pointer
+export %inline
+writeList :
+     (as       : List Bits8)
+  -> (r        : CArray8' t (length as))
+  -> {auto 0 p : Res r rs}
+  -> F1' rs
+writeList as r = writeVect r (fromList as)
+
+export
+withCArray : (n : Nat) -> (f : (r : CArray8 n) -> F1 [r] b) -> b
+withCArray n f =
+  run1 $ \t =>
+    let A r t := Array8.malloc1 n t
+        v # t := f r t
+        _ # t := Array8.free1 r t
+     in v # t
+
+export %inline
+fromListIO :
+     {auto has : HasIO io}
+  -> (as : List Bits8)
+  -> io (CArray8IO (length as))
+fromListIO as = Prelude.do
+  arr <- Array8.malloc (length as)
+  runIO $ writeList as arr
+  pure arr

--- a/src/Data/C/Deref.idr
+++ b/src/Data/C/Deref.idr
@@ -7,54 +7,70 @@ module Data.C.Deref
 --------------------------------------------------------------------------------
 
 %foreign "C:cptr_deref_bits8, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'unsigned-8 x 0))"
 prim__deref_bits8 : AnyPtr -> PrimIO Bits8
 
 %foreign "C:cptr_deref_bits16, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'unsigned-16 x 0))"
 prim__deref_bits16 : AnyPtr -> PrimIO Bits16
 
 %foreign "C:cptr_deref_bits32, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'unsigned-32 x 0))"
 prim__deref_bits32 : AnyPtr -> PrimIO Bits32
 
 %foreign "C:cptr_deref_bits64, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'unsigned-64 x 0))"
 prim__deref_bits64 : AnyPtr -> PrimIO Bits64
 
 %foreign "C:cptr_deref_int8, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'integer-8 x 0))"
 prim__deref_int8 : AnyPtr -> PrimIO Int8
 
 %foreign "C:cptr_deref_int16, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'integer-16 x 0))"
 prim__deref_int16 : AnyPtr -> PrimIO Int16
 
 %foreign "C:cptr_deref_int32, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'integer-32 x 0))"
 prim__deref_int32 : AnyPtr -> PrimIO Int32
 
 %foreign "C:cptr_deref_int64, cptr-idris"
+         "scheme,chez:(lambda (x) (foreign-ref 'integer-64 x 0))"
 prim__deref_int64 : AnyPtr -> PrimIO Int64
 
 %foreign "C:cptr_deref_str, cptr-idris"
 prim__deref_str : AnyPtr -> PrimIO String
 
 %foreign "C:cptr_set_bits8, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'unsigned-8 x 0 y))"
 prim__set_bits8 : AnyPtr -> Bits8 -> PrimIO ()
 
 %foreign "C:cptr_set_bits16, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'unsigned-16 x 0 y))"
 prim__set_bits16 : AnyPtr -> Bits16 -> PrimIO ()
 
 %foreign "C:cptr_set_bits32, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'unsigned-32 x 0 y))"
 prim__set_bits32 : AnyPtr -> Bits32 -> PrimIO ()
 
 %foreign "C:cptr_set_bits64, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'unsigned-64 x 0 y))"
 prim__set_bits64 : AnyPtr -> Bits64 -> PrimIO ()
 
 %foreign "C:cptr_set_int8, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'integer-8 x 0 y))"
 prim__set_int8 : AnyPtr -> Int8 -> PrimIO ()
 
 %foreign "C:cptr_set_int16, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'integer-16 x 0 y))"
 prim__set_int16 : AnyPtr -> Int16 -> PrimIO ()
 
 %foreign "C:cptr_set_int32, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'integer-32 x 0 y))"
 prim__set_int32 : AnyPtr -> Int32 -> PrimIO ()
 
 %foreign "C:cptr_set_int64, cptr-idris"
+         "scheme,chez:(lambda (x y) (foreign-set! 'integer-64 x 0 y))"
 prim__set_int64 : AnyPtr -> Int64 -> PrimIO ()
 
 %foreign "C:cptr_set_str, cptr-idris"

--- a/src/Data/C/Integer.idr
+++ b/src/Data/C/Integer.idr
@@ -95,11 +95,11 @@ public export
 NsecT = Int64
 
 public export %inline
-TimespecSize : Nat
+TimespecSize : Bits32
 TimespecSize = 16
 
 public export %inline
-AnyPtrSize : Nat
+AnyPtrSize : Bits32
 AnyPtrSize = 8
 
 public export

--- a/src/Data/C/SizeOf.idr
+++ b/src/Data/C/SizeOf.idr
@@ -7,10 +7,10 @@ import Data.C.Integer
 ||| Interface for returning the size of a C object in bytes
 public export
 interface SizeOf a where
-  sizeof_ : Nat
+  sizeof_ : Bits32
 
 public export %inline
-sizeof : (0 a : Type) -> SizeOf a => Nat
+sizeof : (0 a : Type) -> SizeOf a => Bits32
 sizeof a = sizeof_ {a}
 
 --------------------------------------------------------------------------------

--- a/support/cptr.c
+++ b/support/cptr.c
@@ -23,7 +23,7 @@ void *cptr_calloc(size_t n, size_t size) {
 
 void *cptr_free(void *ptr) { free(ptr); }
 
-char *cptr_inc_ptr(char *arr, size_t n, size_t pos) { return arr + n*pos; }
+char *cptr_inc_ptr(char *arr, size_t n, size_t pos) { return arr + n * pos; }
 
 uint8_t get_bits8(uint8_t *ptr, uint32_t ix) { return ptr[ix]; }
 

--- a/support/cptr.c
+++ b/support/cptr.c
@@ -23,7 +23,11 @@ void *cptr_calloc(size_t n, size_t size) {
 
 void *cptr_free(void *ptr) { free(ptr); }
 
-char *cptr_inc_ptr(char *arr, size_t pos) { return arr + pos; }
+char *cptr_inc_ptr(char *arr, size_t n, size_t pos) { return arr + n*pos; }
+
+uint8_t get_bits8(uint8_t *ptr, uint32_t ix) { return ptr[ix]; }
+
+void set_bits8(uint8_t *ptr, uint32_t ix, uint8_t v) { ptr[ix] = v; }
 
 uint8_t cptr_deref_bits8(void *ptr) { return *(uint8_t *)ptr; }
 


### PR DESCRIPTION
Going via C function calls for pointer arithmetic, allocating memory, and extracting values from pointers, is horribly slow on Chez. By using Chez's own routines, we can improve performance by a factor of 20 to 30!